### PR TITLE
Add `rust-version` field to the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["systmed", "socket-activation"]
 categories = ["api-bindings", "config", "os::linux-apis"]
 edition = "2018"
 license = "MITNFA"
+rust-version = "1.48.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This is a relatively recent field, so this adds it in line with current MSRV. While the intention is to bump MSRV eventually, I'm holding it off a bit to give people more time.